### PR TITLE
fix: correct getOpenApiDocsUrl to point to valid endpoint

### DIFF
--- a/packages/dkan-client-tools-core/scripts/record-api-responses.ts
+++ b/packages/dkan-client-tools-core/scripts/record-api-responses.ts
@@ -1151,7 +1151,7 @@ class ApiResponseRecorder {
     this.results.push({
       method: 'getOpenApiDocsUrl',
       category: 'OpenAPI',
-      endpoint: '/api/1/docs',
+      endpoint: '/api/1',
       timestamp: new Date().toISOString(),
       response: docsUrl,
       status: 200,

--- a/packages/dkan-client-tools-core/src/api/client.ts
+++ b/packages/dkan-client-tools-core/src/api/client.ts
@@ -1601,11 +1601,34 @@ export class DkanApiClient {
   // ==================== OPENAPI DOCUMENTATION ====================
 
   /**
-   * Get OpenAPI documentation UI URL
-   * Returns the URL to the interactive API documentation
+   * Get OpenAPI specification URL
+   *
+   * Returns the URL to the machine-readable OpenAPI 3.0 specification in JSON format.
+   * This document can be consumed by API documentation tools like Swagger UI, Redoc,
+   * or Postman to provide interactive API documentation.
+   *
+   * @returns URL to the OpenAPI specification (e.g., 'https://dkan.example.com/api/1')
+   *
+   * @example
+   * View in Swagger UI:
+   * ```typescript
+   * const specUrl = client.getOpenApiDocsUrl()
+   * // Open in Swagger UI hosted online
+   * window.open(`https://petstore.swagger.io/?url=${encodeURIComponent(specUrl)}`)
+   * ```
+   *
+   * @example
+   * Fetch and inspect the spec:
+   * ```typescript
+   * const specUrl = client.getOpenApiDocsUrl()
+   * const response = await fetch(specUrl)
+   * const openApiSpec = await response.json()
+   * console.log(`API Version: ${openApiSpec.info.version}`)
+   * console.log(`Available paths: ${Object.keys(openApiSpec.paths).length}`)
+   * ```
    */
   getOpenApiDocsUrl(): string {
-    return `${this.baseUrl}/api/1/docs`
+    return `${this.baseUrl}/api/1`
   }
 
 }

--- a/packages/dkan-client-tools-core/src/client/dkanClient.ts
+++ b/packages/dkan-client-tools-core/src/client/dkanClient.ts
@@ -971,11 +971,12 @@ export class DkanClient {
   // ==================== OPENAPI DOCUMENTATION ====================
 
   /**
-   * Get OpenAPI documentation UI URL.
+   * Get OpenAPI specification URL
    *
-   * Returns the URL to the interactive Swagger UI documentation for the DKAN API.
+   * Returns the URL to the machine-readable OpenAPI 3.0 specification in JSON format.
+   * This can be used with documentation tools like Swagger UI, Redoc, or Postman.
    *
-   * @returns URL to the OpenAPI documentation interface
+   * @returns URL to the OpenAPI specification (e.g., 'https://dkan.example.com/api/1')
    */
   getOpenApiDocsUrl() {
     return this.apiClient.getOpenApiDocsUrl()


### PR DESCRIPTION
The method was returning /api/1/docs which returns 404. DKAN actually serves the OpenAPI 3.0 spec at /api/1 (verified in routing config and live test site).

Changes:
- Update URL from /api/1/docs to /api/1
- Enhance JSDoc with examples of using with Swagger UI
- Update test script fixture endpoint
- Clarify that it returns OpenAPI spec (JSON) not UI

Verified: https://dkan.ddev.site/api/1 returns 200 OK with valid spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)