### PR TITLE
docs(core): clarify authentication methods for DKAN 2.x

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -372,9 +372,11 @@ The packages integrate with DKAN's REST APIs. See `research/DKAN_API_RESEARCH.md
 
 ### Authentication
 
-- HTTP Basic Authentication (username/password)
-- Bearer tokens (if configured)
-- Anonymous read access (no auth required for GET requests)
+- **HTTP Basic Authentication** (username/password) - Works with DKAN 2.x out-of-the-box
+- **Bearer tokens** - Requires additional Drupal modules (NOT supported by default in DKAN 2.x)
+- **Anonymous read access** - No auth required for GET requests to public endpoints
+
+**Note**: For standard DKAN 2.x installations, use HTTP Basic Authentication. Token authentication requires installing additional modules like Simple OAuth.
 
 ## Architecture Patterns
 

--- a/packages/dkan-client-tools-core/README.md
+++ b/packages/dkan-client-tools-core/README.md
@@ -150,16 +150,11 @@ This package leverages [TanStack Query Core](https://tanstack.com/query) for sta
 
 Supports two authentication methods:
 
-```typescript
-// Token-based authentication
-const client = new DkanClient({
-  baseUrl: 'https://your-dkan-site.com',
-  auth: {
-    token: 'your-api-token',
-  },
-})
+### HTTP Basic Authentication (Recommended)
 
-// Basic authentication
+**Works with DKAN 2.x out-of-the-box.** This is the standard authentication method for DKAN.
+
+```typescript
 const client = new DkanClient({
   baseUrl: 'https://your-dkan-site.com',
   auth: {
@@ -168,6 +163,22 @@ const client = new DkanClient({
   },
 })
 ```
+
+### Bearer Token Authentication
+
+**Requires additional Drupal modules.** Token authentication is NOT supported by DKAN 2.x by default. You must install and configure additional modules (e.g., Simple OAuth) on your DKAN instance to use this method.
+
+```typescript
+// Only works if your DKAN instance has token auth modules installed
+const client = new DkanClient({
+  baseUrl: 'https://your-dkan-site.com',
+  auth: {
+    token: 'your-api-token',
+  },
+})
+```
+
+**Note**: If you're using a standard DKAN 2.x installation, use Basic Authentication.
 
 ## TypeScript Types
 

--- a/packages/dkan-client-tools-core/src/api/client.ts
+++ b/packages/dkan-client-tools-core/src/api/client.ts
@@ -49,8 +49,8 @@
  *     - getBaseUrl, getDefaultOptions, getOpenApiDocsUrl
  *
  * **Authentication**:
- * - HTTP Basic Authentication (username + password)
- * - Bearer token authentication
+ * - HTTP Basic Authentication (username + password) - **RECOMMENDED** for DKAN 2.x
+ * - Bearer token authentication - Requires additional Drupal modules (NOT supported by default)
  * - Anonymous access for public endpoints
  *
  * **Error Handling**:

--- a/packages/dkan-client-tools-core/src/types.ts
+++ b/packages/dkan-client-tools-core/src/types.ts
@@ -203,9 +203,19 @@ export interface DkanClientConfig {
   defaultOptions?: DkanDefaultOptions
 }
 
+/**
+ * Authentication configuration for DKAN API client
+ *
+ * **DKAN 2.x Authentication Support:**
+ * - Basic Auth (username/password) works out-of-the-box
+ * - Bearer token requires additional Drupal modules (e.g., Simple OAuth)
+ */
 export interface DkanAuth {
+  /** Username for HTTP Basic Authentication - Works with DKAN 2.x out-of-the-box */
   username?: string
+  /** Password for HTTP Basic Authentication - Works with DKAN 2.x out-of-the-box */
   password?: string
+  /** Bearer token - Requires additional Drupal modules, NOT supported by default in DKAN 2.x */
   token?: string
 }
 


### PR DESCRIPTION
Update documentation to clearly distinguish between authentication methods and their DKAN 2.x support:
- HTTP Basic Auth works out-of-the-box
- Bearer token requires additional Drupal modules

Updated files:
- Core README with recommended auth method
- DkanAuth type definitions with usage notes
- DkanApiClient documentation
- Project overview in CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)