### PR TITLE
Add clean refresh option to DKAN setup commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,8 +277,11 @@ cd dkan
 ddev drush si --account-pass=admin -y
 ddev start  # Automated setup runs on post-start hook
 
-# Manual setup script
+# Manual setup script (idempotent)
 ddev exec bash scripts/setup-site.sh
+
+# Clean refresh (removes demo content and sample datasets, then recreates)
+ddev exec bash scripts/setup-site.sh -c
 
 # Complete rebuild (destroys database)
 ddev exec bash scripts/rebuild-site.sh
@@ -286,9 +289,11 @@ ddev exec bash scripts/rebuild-site.sh
 
 **Automation Drush Commands**:
 ```bash
-ddev drush dkan-client:create-demo-pages  # Create demo pages
-ddev drush dkan-client:place-blocks       # Place demo blocks
-ddev drush dkan-client:setup              # Complete setup (pages + blocks)
+ddev drush dkan-client:create-demo-pages     # Create demo pages
+ddev drush dkan-client:place-blocks          # Place demo blocks
+ddev drush dkan-client:create-data-dictionaries  # Create data dictionaries
+ddev drush dkan-client:setup                 # Complete setup (idempotent)
+ddev drush dkan-client:setup --clean         # Clean refresh (removes all, then recreates)
 ```
 
 **Common Commands**:
@@ -567,6 +572,7 @@ Fetch a single dataset by identifier.
   - Commit: Add at end of commit body (not subject line)
   - PR: Add at bottom of description with separator line
   - Format: `🤖 Generated with [Claude Code](https://claude.com/claude-code)`
+- PR descriptions should also include `Co-Authored-By: Claude <noreply@anthropic.com>`
 
 **Important Notes**:
 - Dataset Properties API endpoints return 404 in DKAN 2.x (not available)

--- a/dkan/docroot/modules/custom/dkan_client_setup/README.md
+++ b/dkan/docroot/modules/custom/dkan_client_setup/README.md
@@ -88,6 +88,27 @@ ddev drush dkan-client:create-data-dictionaries
 
 **Idempotent:** Safe to run multiple times.
 
+### Clean Refresh
+
+Remove all existing demo content and sample datasets, then recreate:
+
+```bash
+ddev drush dkan-client:setup --clean
+```
+
+**Removes:**
+- Demo pages (3 pages)
+- Demo blocks (3 blocks)
+- Data dictionaries (all *-dict items)
+- Sample datasets (reverts sample_content harvest)
+
+**Then Creates:**
+- Fresh demo pages
+- Fresh demo blocks
+- Fresh data dictionaries
+
+**Use Case:** Reset demo environment to clean state.
+
 ## Aliases
 
 Short aliases available:
@@ -96,7 +117,9 @@ Short aliases available:
 - `dkan-client-dictionaries` → `dkan-client:create-data-dictionaries`
 - `dkan-client-demo-setup` → `dkan-client:setup`
 
-## Usage Example
+## Usage Examples
+
+### Normal Setup (Idempotent)
 
 ```bash
 # Enable module
@@ -109,6 +132,17 @@ ddev drush dkan-client:setup
 open https://dkan.ddev.site/vanilla-demo
 open https://dkan.ddev.site/react-demo
 open https://dkan.ddev.site/vue-demo
+```
+
+### Clean Refresh
+
+```bash
+# Remove all demo content and sample datasets, then recreate
+ddev drush dkan-client:setup --clean
+
+# Or via bash script
+cd /path/to/dkan
+bash scripts/setup-site.sh -c
 ```
 
 ## Architecture

--- a/dkan/docroot/modules/custom/dkan_client_setup/drush.services.yml
+++ b/dkan/docroot/modules/custom/dkan_client_setup/drush.services.yml
@@ -7,5 +7,6 @@ services:
       - '@dkan.metastore.service'
       - '@dkan.metastore.storage'
       - '@dkan.metastore.data_dictionary_discovery'
+      - '@dkan.harvest.service'
     tags:
       - { name: drush.command }

--- a/dkan/scripts/setup-site.sh
+++ b/dkan/scripts/setup-site.sh
@@ -6,8 +6,28 @@
 # Automates complete DKAN development environment setup.
 # Idempotent - safe to run multiple times.
 #
+# Usage:
+#   ./setup-site.sh       # Normal idempotent setup
+#   ./setup-site.sh -c    # Clean refresh (removes all demo content and sample datasets first)
+#
 
 set -e  # Exit on error
+
+# Parse command line options
+CLEAN_FIRST=false
+while getopts "c" opt; do
+  case $opt in
+    c)
+      CLEAN_FIRST=true
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      echo "Usage: $0 [-c]" >&2
+      echo "  -c  Clean refresh (remove existing demo content and sample datasets first)" >&2
+      exit 1
+      ;;
+  esac
+done
 
 # Color codes
 GREEN='\033[0;32m'
@@ -32,8 +52,22 @@ fi
 echo ""
 echo "========================================="
 echo " DKAN Client Tools - Site Setup"
+if [ "$CLEAN_FIRST" = true ]; then
+  echo " (Clean Refresh Mode)"
+fi
 echo "========================================="
 echo ""
+
+# Clean existing content if requested
+if [ "$CLEAN_FIRST" = true ]; then
+  echo -e "${YELLOW}Clean mode enabled - removing existing demo content and sample datasets...${NC}"
+  echo ""
+  drush dkan-client:setup --clean
+  echo ""
+  echo -e "${CHECK} Clean refresh complete!"
+  echo ""
+  exit 0
+fi
 
 # Step 1: Verify Drupal installation
 echo -e "${CHECK} Step 1/10: Verifying Drupal installation..."


### PR DESCRIPTION
## Summary

Adds clean refresh functionality to DKAN setup automation, allowing users to remove all existing demo content and sample datasets before recreating them.

## Changes

### Drush Commands
- Added `--clean` flag to `dkan-client:setup` command
- Implemented cleanup methods:
  - `cleanAll()` - Orchestrates full cleanup
  - `cleanDemoPages()` - Removes 3 demo pages
  - `cleanBlocks()` - Removes 3 demo blocks
  - `cleanDataDictionaries()` - Removes all *-dict items
  - `cleanSampleContent()` - Reverts sample_content harvest
- Injected `HarvestService` for sample content cleanup

### Bash Script
- Added `-c` flag to `setup-site.sh`
- Script calls `drush dkan-client:setup --clean` when `-c` is used

### Documentation
- Updated `dkan_client_setup/README.md` with clean refresh examples
- Updated `CLAUDE.md` with new command options

## Usage

```bash
# Drush command
ddev drush dkan-client:setup --clean

# Bash script
cd dkan
ddev exec bash scripts/setup-site.sh -c
```

## Testing

All tests passed:
- ✅ Idempotent setup (no regression)
- ✅ Clean refresh with Drush command
- ✅ Bash script with -c flag
- ✅ Content properly removed and recreated

## Closes

Fixes #85

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>